### PR TITLE
Updated mongoid ~> 2.4

### DIFF
--- a/lib/mongoid/searchable.rb
+++ b/lib/mongoid/searchable.rb
@@ -110,7 +110,6 @@ module Mongoid
 
     end
 
-    module InstanceMethods
 
       # Builds a list of keywords contained in the document given the
       # keyword fields previously declared and stores them in the
@@ -125,7 +124,6 @@ module Mongoid
         write_attribute(self.class.keywords_field, keywords.flatten.uniq)
       end
 
-    end
 
   end
 

--- a/mongoid-searchable.gemspec
+++ b/mongoid-searchable.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.summary = 'Simple keyword search for your Mongoid models.'
   s.description = 'Mongoid Searchable allows you to easily perform full-text search your Mongoid models.'
 
-  s.add_dependency 'mongoid', '~> 2.1'
-  s.add_dependency 'bson_ext', '~> 1.3'
+  s.add_dependency 'mongoid', '~> 2.4'
+  s.add_dependency 'bson_ext', '~> 1.6'
   s.add_development_dependency 'growl'
   s.add_development_dependency 'rake', '~> 0.9.2'
-  s.add_development_dependency 'rspec', '~> 2.6'
-  s.add_development_dependency 'guard-rspec', '~> 0.4.3'
+  s.add_development_dependency 'rspec', '~> 2.9'
+  s.add_development_dependency 'guard-rspec', '~> 0.7'
 
   s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.md"]
   s.require_paths = ['lib']


### PR DESCRIPTION
Stop relying on ActiveSupport::Concern's deprecated inclusion of the InstanceMethods module.
